### PR TITLE
APIのURLを環境変数に出す

### DIFF
--- a/.env
+++ b/.env
@@ -2,3 +2,4 @@ COMPOSE_PROJECT_NAME=chart-js-app
 POSTGRES_DB=chart_js_app
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=password
+NEXT_PUBLIC_API_BASE_URL=http://localhost:3000

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -40,7 +40,9 @@ export default Home;
 export const getServerSideProps: GetServerSideProps<{
   cereals: Cereal[];
 }> = async () => {
-  const response = await fetch("http://localhost:3000/api/cereals");
+  const response = await fetch(
+    `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/cereals`,
+  );
   const cereals = await response.json();
   return {
     props: { cereals },


### PR DESCRIPTION
# 概要

APIをlocalhostの文字列で指定していたので、vercelにデプロイするためにAPIのパスを環境変数に出しました